### PR TITLE
Fix for #17: Add tests & support for vertical video resolutions + Formatting Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ $ aspect-ratio
     $ aspect-ratio <width><height>[options]
 
     options:
-  	 -s	     specified a separator. (by default is ':').
-  	 --version   output the current version.
+     -s          specified a separator. (by default is ':').
+     --version   output the current version.
 
     examples:
-  	 aspect-ratio 1920 1080
-  	 aspect-ratio 800 600 -s /
+     aspect-ratio 1920 1080
+     aspect-ratio 800 600 -s /
 ```
 
 ## License

--- a/bin/index.js
+++ b/bin/index.js
@@ -5,7 +5,7 @@ const cli = require('meow')({
   pkg: '../package.json',
   help: [
     'Usage',
-    '  $ aspect-ratio <width><height>[options]',
+    '  $ aspect-ratio <width> <height> [options]',
     '\n  options:',
     "\t -s\t     specified a separator. (by default is ':').",
     '\t --version   output the current version.',

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 const { gcd, highestFirst, formatAspectRatio } = require('./util')
 
-module.exports = (height, width, seperator = ':') => {
+module.exports = (width, height, seperator = ':') => {
   if (typeof height !== 'number') {
     throw new Error(
       `Invalid height: expected a \`number\`, received \`${height}\``
@@ -17,5 +17,5 @@ module.exports = (height, width, seperator = ':') => {
 
   const [h, w] = highestFirst(height, width)
   const divisor = gcd(h, w)
-  return formatAspectRatio(h, w, divisor, seperator)
+  return formatAspectRatio(width, height, divisor, seperator)
 }

--- a/test/index.js
+++ b/test/index.js
@@ -5,8 +5,13 @@ const should = require('should')
 
 describe('aspect ratio', () => {
   it('1024x768', () => should(aspectRatio(1024, 768)).equal('4:3'))
+  it('768x1024', () => should(aspectRatio(768, 1024)).equal('3:4'))
   it('1920x1080', () => should(aspectRatio(1920, 1080)).equal('16:9'))
   it('1280x1024', () => should(aspectRatio(1280, 1024)).equal('5:4'))
+  it('1024x1280', () => should(aspectRatio(1024, 1280)).equal('4:5'))
+  it('1080x1920', () => should(aspectRatio(1080, 1920)).equal('9:16'))
+  it('3840x2160', () => should(aspectRatio(3840, 2160)).equal('16:9'))
+  it('2160x3840', () => should(aspectRatio(2160, 3840)).equal('9:16'))
   it('specifying output separator', () =>
     should(aspectRatio(1920, 1080, '/')).equal('16/9'))
 


### PR DESCRIPTION
Fix for #17

Vertical video resolutions are on the rise and this library was always showing the "highest" value between width and height first. Now it keeps the order in tact and returns whatever height & width was used correctly.

Additionally, reordered the input variables to make more sense. This has the input variable order represented correctly in the output string which is always `width x height`.

And I added some formatting fixes while checking up on the cli + readme file.